### PR TITLE
Add UCM files for Aries and Fascinate

### DIFF
--- a/usr/share/alsa/ucm/Aries/Aries.conf
+++ b/usr/share/alsa/ucm/Aries/Aries.conf
@@ -1,0 +1,22 @@
+SectionUseCase."HiFi" {
+  File "hifi"
+  Comment "Hifi audio path"
+}
+
+SectionUseCase."Voice Call" {
+  File "voicecall"
+  Comment "Voice call audio path"
+}
+
+SectionUseCase."FM Analog Radio" {
+  File "fmradio"
+  Comment "FM analog Radio"
+}
+
+ValueDefaults {
+  PlaybackCTL "hw:0"
+  CaptureCTL "hw:0"
+}
+
+SectionDefaults {
+}

--- a/usr/share/alsa/ucm/Aries/fmradio
+++ b/usr/share/alsa/ucm/Aries/fmradio
@@ -1,0 +1,130 @@
+# Use case Configuration for Mobile device
+# By Inha Song <ideal.song@samsung.com>
+
+SectionVerb {
+  EnableSequence [
+  ]
+  DisableSequence [
+  ]
+
+  Value {
+    TQ "Music"
+    PlaybackCTL "hw:0"
+    CaptureCTL "hw:0"
+  }
+}
+
+SectionDevice."Headphones" {
+  Comment "3.5mm Headphones"
+
+  EnableSequence [
+# Path
+    cset "name='Right Output Mixer IN2RP Switch' on"
+    cset "name='Left Output Mixer IN2RN Switch' on"
+    cset "name='Right Headphone Mux' DAC"
+    cset "name='Left Headphone Mux' DAC"
+    cset "name='Left Output Mixer DAC Switch' on"
+    cset "name='Right Output Mixer DAC Switch' on"
+    cset "name='Headphone Switch' on"
+    cset "name='HP Switch' on"
+    cset "name='FM In Switch' on"
+  ]
+
+  DisableSequence [
+    cset "name='Right Output Mixer IN2RP Switch' off"
+    cset "name='Left Output Mixer IN2RN Switch' off"
+    cset "name='Left Output Mixer DAC Switch' off"
+    cset "name='Right Output Mixer DAC Switch' off"
+    cset "name='Headphone Switch' off"
+    cset "name='HP Switch' off"
+    cset "name='FM In Switch' off"
+  ]
+
+  Value {
+    PlaybackChannels 2
+    PlaybackPriority 105
+    PlaybackVolume "Headphone Volume"
+    JackControl "HP Jack"
+  }
+}
+
+SectionDevice."Speaker" {
+  Comment "built-in Speaker"
+
+  EnableSequence [
+# Gain
+    cset "name='IN2R Volume' 31"
+    cset "name='MIXINR IN2R Volume' 1"
+    cset "name='Speaker Mixer Volume' 3,3"
+    cset "name='Speaker Volume' 60,60"
+    cset "name='Speaker Boost Volume' 7,7"
+# Path
+    cset "name='IN2R PGA IN2RN Switch' on"
+    cset "name='IN2R PGA IN2RP Switch' on"
+    cset "name='IN2R Switch' on"
+    cset "name='MIXINR IN2R Switch' on"
+    cset "name='ADCR Mux' ADC"
+    cset "name='DAC1R Mixer Right Sidetone Switch' on"
+    cset "name='DAC1L Mixer Right Sidetone Switch' on"
+    cset "name='DAC1 Switch' on"
+    cset "name='SPKL DAC1 Switch' on"
+    cset "name='SPKR DAC1 Switch' on"
+    cset "name='SPKL Boost SPKL Switch' on"
+    cset "name='SPKR Boost SPKR Switch' on"
+    cset "name='Speaker Switch' on"
+    cset "name='SPK Switch' on"
+    cset "name='FM In Switch' on"
+  ]
+
+  DisableSequence [
+    cset "name='IN2R PGA IN2RN Switch' off"
+    cset "name='IN2R PGA IN2RP Switch' off"
+    cset "name='IN2R Switch' off"
+    cset "name='MIXINR IN2R Switch' off"
+    cset "name='DAC1R Mixer Right Sidetone Switch' off"
+    cset "name='DAC1L Mixer Right Sidetone Switch' off"
+    cset "name='DAC1 Switch' off"
+    cset "name='SPKL DAC1 Switch' off"
+    cset "name='SPKR DAC1 Switch' off"
+    cset "name='SPKL Boost SPKL Switch' off"
+    cset "name='SPKR Boost SPKR Switch' off"
+    cset "name='Speaker Switch' off"
+    cset "name='SPK Switch' off"
+    cset "name='FM In Switch' off"
+  ]
+
+  Value {
+    PlaybackChannels 2
+    PlaybackPriority 100
+    PlaybackVolume "Speaker Volume"
+  }
+}
+
+SectionModifier."Capture Music" {
+  Comment "recording FM Radio"
+
+  EnableSequence [
+# Gain
+    cset "name='IN2R Volume' 11"
+    cset "name='MIXINR IN2R Volume' 0"
+    cset "name='MIXINR Direct Voice Volume' 6"
+# Path
+    cset "name='IN2R Switch' on"
+    cset "name='MIXINR IN2R Switch' on"
+    cset "name='ADCR Mux' ADC"
+    cset "name='AIF1ADC1R Mixer ADC/DMIC Switch' on"
+    cset "name='AIF1ADCR Source' Right"
+    cset "name='AIF1ADCL Source' Right"
+  ]
+
+  DisableSequence [
+    cset "name='IN2R Switch' off"
+    cset "name='MIXINR IN2R Switch' off"
+    cset "name='AIF1ADC1R Mixer ADC/DMIC Switch' off"
+    cset "name='AIF1ADCR Source' Left"
+    cset "name='AIF1ADCL Source' Left"
+  ]
+
+  Value {
+  }
+}

--- a/usr/share/alsa/ucm/Aries/hifi
+++ b/usr/share/alsa/ucm/Aries/hifi
@@ -1,0 +1,232 @@
+# Use case Configuration for Mobile device
+# By Inha Song <ideal.song@samsung.com>
+
+SectionVerb {
+  EnableSequence [
+    cset "name='DAC1L Mixer AIF1.1 Switch' 1"
+    cset "name='DAC1R Mixer AIF1.1 Switch' 1"
+    cset "name='DAC1 Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='DAC1L Mixer AIF1.1 Switch' 0"
+    cset "name='DAC1R Mixer AIF1.1 Switch' 0"
+    cset "name='DAC1 Switch' 0"
+  ]
+
+  Value {
+    TQ "Music"
+    CaptureCTL "hw:0"
+    PlaybackCTL "hw:0"
+  }
+}
+
+SectionDevice."Headphones" {
+  Comment "3.5mm Headphones"
+
+  EnableSequence [
+    cset "name='Headphone Switch' 1"
+    cset "name='Headphone Volume' 43"
+    cset "name='Left Headphone Mux' DAC"
+    cset "name='Right Headphone Mux' DAC"
+
+    cset "name='HP Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='Headphone Switch' 0"
+
+    cset "name='HP Switch' 0"
+  ]
+
+  Value {
+    PlaybackChannels 2
+    PlaybackPCM "hw:0,0"
+    PlaybackPriority 110
+    PlaybackVolume "Headphone Volume"
+    JackControl "HP Jack"
+  }
+}
+
+SectionDevice."Speaker" {
+  Comment "built-in Speaker"
+
+  EnableSequence [
+    cset "name='Speaker Switch' 1"
+    cset "name='Speaker Volume' 63"
+    cset "name='Speaker Boost Volume' 6"
+    cset "name='Speaker Mixer Volume' 3"
+    cset "name='SPKL DAC1 Switch' 1"
+
+    cset "name='SPK Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='Speaker Switch' 0"
+    cset "name='SPKL DAC1 Switch' 0"
+
+    cset "name='SPK Switch' 0"
+  ]
+
+  Value {
+    PlaybackChannels 1
+    PlaybackPCM "hw:0,0"
+    PlaybackPriority 105
+    PlaybackVolume "Speaker Volume"
+  }
+}
+
+SectionDevice."Earpiece" {
+  Comment "built-in earpiece, receiver"
+
+  EnableSequence [
+    cset "name='Earpiece Switch' 1"
+    cset "name='Earpiece Mixer Left Output Switch' 1"
+    cset "name='Earpiece Mixer Right Output Switch' 1"
+    cset "name='Left Output Mixer DAC Switch' 1"
+    cset "name='Right Output Mixer DAC Switch' 1"
+
+    cset "name='RCV Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='Earpiece Switch' 0"
+    cset "name='Earpiece Mixer Left Output Switch' 0"
+    cset "name='Earpiece Mixer Right Output Switch' 0"
+    cset "name='Left Output Mixer DAC Switch' 0"
+    cset "name='Right Output Mixer DAC Switch' 0"
+
+    cset "name='RCV Switch' 0"
+  ]
+
+  Value {
+    PlaybackChannels 2
+    PlaybackPCM "hw:0,0"
+    PlaybackPriority 100
+    PlaybackVolume "Earpiece Volume"
+  }
+}
+
+SectionDevice."Line" {
+  Comment "lineout for dock"
+
+
+  EnableSequence [
+# Gain
+    cset "name='LINEOUT2 Volume' 0"
+# FSA9480
+    exec "echo VAUDIO > /sys/devices/platform/i2c-gpio-3/i2c-7/7-0025/switch"
+# Path
+    cset "name='Right Output Mixer DAC Switch' 1"
+    cset "name='Left Output Mixer DAC Switch' 1"
+    cset "name='LINEOUT2N Mixer Left Output Switch' 1"
+    cset "name='LINEOUT2P Mixer Right Output Switch' 1"
+    cset "name='LINEOUT2N Switch' 1"
+    cset "name='LINEOUT2P Switch' 1"
+
+    cset "name='LINE Switch' 1"
+  ]
+
+  DisableSequence [
+# FSA9480
+    exec "echo AUTO > /sys/devices/platform/i2c-gpio-3/i2c-7/7-0025/switch"
+# Path
+    cset "name='Right Output Mixer DAC Switch' 0"
+    cset "name='Left Output Mixer DAC Switch' 0"
+    cset "name='LINEOUT2N Mixer Left Output Switch' 0"
+    cset "name='LINEOUT2P Mixer Right Output Switch' 0"
+    cset "name='LINEOUT2N Switch' 0"
+    cset "name='LINEOUT2P Switch' 0"
+
+    cset "name='LINE Switch' 0"
+  ]
+
+  Value {
+    PlaybackChannels 2
+    PlaybackPCM "hw:0,0"
+    PlaybackPriority 115
+    PlaybackVolume "LINEOUT2 Volume"
+    JackControl "LINE Jack"
+  }
+}
+
+SectionDevice."MainMic" {
+  Comment "built-in main mic"
+
+  EnableSequence [
+    cset "name='AIF1ADCL Source' Left"
+    cset "name='AIF1ADCR Source' Left"
+    cset "name='AIF1ADC1L Mixer ADC/DMIC Switch' 1"
+    cset "name='AIF1ADC1R Mixer ADC/DMIC Switch' 1"
+    cset "name='MIXINL IN1L Switch' 1"
+    cset "name='MIXINL IN1L Volume' 1"
+    cset "name='IN1L PGA IN1LN Switch' 1"
+    cset "name='IN1L PGA IN1LP Switch' 1"
+    cset "name='IN1L Switch' 1"
+    cset "name='IN1L ZC Switch' 1"
+    cset "name='IN1L Volume' 31"
+
+    cset "name='Main Mic Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='AIF1ADCR Source' Right"
+    cset "name='AIF1ADC1L Mixer ADC/DMIC Switch' 0"
+    cset "name='AIF1ADC1R Mixer ADC/DMIC Switch' 0"
+    cset "name='MIXINL IN1L Switch' 0"
+    cset "name='IN1L PGA IN1LN Switch' 0"
+    cset "name='IN1L PGA IN1LP Switch' 0"
+    cset "name='IN1L Switch' 0"
+    cset "name='IN1L ZC Switch' 0"
+
+    cset "name='Main Mic Switch' 0"
+  ]
+
+  Value {
+    CaptureChannels 2
+    CapturePCM "hw:0,0"
+    CapturePriority 100
+    CaptureVolume "IN1L Volume"
+  }
+}
+
+SectionDevice."HeadsetMic" {
+  Comment "external headset mic"
+
+  EnableSequence [
+    cset "name='AIF1ADCL Source' Right"
+    cset "name='AIF1ADCR Source' Right"
+    cset "name='AIF1ADC1L Mixer ADC/DMIC Switch' 1"
+    cset "name='AIF1ADC1R Mixer ADC/DMIC Switch' 1"
+    cset "name='MIXINR IN1R Switch' 1"
+    cset "name='MIXINR IN1R Volume' 1"
+    cset "name='IN1R PGA IN1RN Switch' 1"
+    cset "name='IN1R PGA IN1RP Switch' 1"
+    cset "name='IN1R Switch' 1"
+    cset "name='IN1R ZC Switch' 1"
+    cset "name='IN1R Volume' 31"
+
+    cset "name='Headset Mic Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='AIF1ADCL Source' Left"
+    cset "name='AIF1ADC1L Mixer ADC/DMIC Switch' 0"
+    cset "name='AIF1ADC1R Mixer ADC/DMIC Switch' 0"
+    cset "name='MIXINR IN1R Switch' 0"
+    cset "name='IN1R PGA IN1RN Switch' 0"
+    cset "name='IN1R PGA IN1RP Switch' 0"
+    cset "name='IN1R Switch' 0"
+    cset "name='IN1R ZC Switch' 0"
+
+    cset "name='Headset Mic Switch' 0"
+  ]
+
+  Value {
+    CaptureChannels 2
+    CapturePCM "hw:0,0"
+    CapturePriority 105
+    CaptureVolume "IN1R Volume"
+    JackControl "Headset Mic Jack"
+  }
+}

--- a/usr/share/alsa/ucm/Aries/voicecall
+++ b/usr/share/alsa/ucm/Aries/voicecall
@@ -1,0 +1,260 @@
+# Use case Configuration for Mobile device
+# By Inha Song <ideal.song@samsung.com>
+
+SectionVerb {
+  EnableSequence [
+    # Common gain values
+    # 0dB
+    cset "name='DAC1 Volume' 96"
+
+    # 0dB
+    cset "name='DAC2 Volume' 96"
+
+    cset "name='DAC2 Right Sidetone Volume' 12"
+    cset "name='DAC2 Left Sidetone Volume' 12"
+    cset "name='DAC OSR' 1"
+    cset "name='ADC OSR' 0"
+
+    cset "name='DAC1R Mixer AIF2 Switch' 1"
+    cset "name='DAC1L Mixer AIF2 Switch' 1"
+    cset "name='DAC1 Switch' 1"
+
+    # DAC2 is connected to AIF2
+    cset "name='DAC2 Switch' 1"
+
+    cset "name='Modem In Switch' 1"
+    cset "name='Modem Out Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='DAC1R Mixer AIF2 Switch' 0"
+    cset "name='DAC1L Mixer AIF2 Switch' 0"
+    cset "name='DAC1 Switch' 0"
+
+    cset "name='DAC2 Switch' 0"
+
+    cset "name='Modem In Switch' 0"
+    cset "name='Modem Out Switch' 0"
+  ]
+
+  Value {
+    TQ "Voice"
+    CaptureCTL "hw:0"
+    PlaybackCTL "hw:0"
+  }
+}
+
+SectionDevice."Headphones" {
+  Comment "3.5mm Headphones"
+
+  EnableSequence [
+    cset "name='Headphone Switch' 1"
+    cset "name='Headphone Volume' 43"
+    cset "name='Left Headphone Mux' DAC"
+    cset "name='Right Headphone Mux' DAC"
+
+    cset "name='HP Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='Headphone Switch' 0"
+
+    cset "name='HP Switch' 0"
+  ]
+
+  Value {
+    PlaybackChannels 2
+    PlaybackPCM "hw:0,0"
+    PlaybackPriority 110
+    PlaybackVolume "Headphone Volume"
+    JackControl "HP Jack"
+  }
+}
+
+SectionDevice."Speaker" {
+  Comment "built-in Speaker"
+
+  EnableSequence [
+    cset "name='Speaker Switch' 1"
+    cset "name='Speaker Volume' 63"
+    cset "name='Speaker Boost Volume' 6"
+    cset "name='Speaker Mixer Volume' 3"
+    cset "name='SPKL DAC1 Switch' 1"
+
+    cset "name='SPK Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='Speaker Switch' 0"
+    cset "name='SPKL DAC1 Switch' 0"
+
+    cset "name='SPK Switch' 0"
+  ]
+
+  Value {
+    PlaybackChannels 1
+    PlaybackPCM "hw:0,0"
+    PlaybackPriority 100
+    PlaybackVolume "Speaker Volume"
+  }
+}
+
+SectionDevice."Earpiece" {
+  Comment "built-in earpiece, receiver"
+
+  EnableSequence [
+    cset "name='Left Output Mixer DAC Volume' 7"
+    cset "name='Right Output Mixer DAC Volume' 7"
+    cset "name='Output Volume' 63"
+    cset "name='Earpiece Volume' 1"
+
+    cset "name='Earpiece Switch' 1"
+    cset "name='Earpiece Mixer Left Output Switch' 1"
+    cset "name='Earpiece Mixer Right Output Switch' 1"
+    cset "name='Left Output Mixer DAC Switch' 1"
+    cset "name='Right Output Mixer DAC Switch' 1"
+
+    cset "name='RCV Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='Earpiece Switch' 0"
+    cset "name='Earpiece Mixer Left Output Switch' 0"
+    cset "name='Earpiece Mixer Right Output Switch' 0"
+    cset "name='Left Output Mixer DAC Switch' 0"
+    cset "name='Right Output Mixer DAC Switch' 0"
+
+    cset "name='RCV Switch' 0"
+  ]
+
+  Value {
+    PlaybackChannels 2
+    PlaybackPCM "hw:0,0"
+    PlaybackPriority 105
+    PlaybackVolume "Earpiece Volume"
+  }
+}
+
+SectionDevice."Line" {
+  Comment "lineout for dock"
+
+
+  EnableSequence [
+# Gain
+    cset "name='LINEOUT2 Volume' 0"
+# FSA9480
+    exec "echo VAUDIO > /sys/devices/platform/i2c-gpio-3/i2c-7/7-0025/switch"
+# Path
+    cset "name='Right Output Mixer DAC Switch' 1"
+    cset "name='Left Output Mixer DAC Switch' 1"
+    cset "name='LINEOUT2N Mixer Left Output Switch' 1"
+    cset "name='LINEOUT2P Mixer Right Output Switch' 1"
+    cset "name='LINEOUT2N Switch' 1"
+    cset "name='LINEOUT2P Switch' 1"
+
+    cset "name='LINE Switch' 1"
+  ]
+
+  DisableSequence [
+# FSA9480
+    exec "echo AUTO > /sys/devices/platform/i2c-gpio-3/i2c-7/7-0025/switch"
+# Path
+    cset "name='Right Output Mixer DAC Switch' 0"
+    cset "name='Left Output Mixer DAC Switch' 0"
+    cset "name='LINEOUT2N Mixer Left Output Switch' 0"
+    cset "name='LINEOUT2P Mixer Right Output Switch' 0"
+    cset "name='LINEOUT2N Switch' 0"
+    cset "name='LINEOUT2P Switch' 0"
+
+    cset "name='LINE Switch' 0"
+  ]
+
+  Value {
+    PlaybackChannels 2
+    PlaybackPCM "hw:0,0"
+    PlaybackPriority 115
+    PlaybackVolume "LINEOUT2 Volume"
+    JackControl "LINE Jack"
+  }
+}
+
+SectionDevice."MainMic" {
+  Comment "built-in main mic"
+
+  EnableSequence [
+    cset "name='AIF2DAC2L Mixer Left Sidetone Switch' 1"
+    cset "name='AIF2DAC2R Mixer Left Sidetone Switch' 1"
+
+    cset "name='MIXINL IN1L Switch' 1"
+    cset "name='MIXINL IN1L Volume' 1"
+    cset "name='IN1L PGA IN1LN Switch' 1"
+    cset "name='IN1L PGA IN1LP Switch' 1"
+    cset "name='IN1L Switch' 1"
+    cset "name='IN1L ZC Switch' 1"
+    cset "name='IN1L Volume' 25"
+    cset "name='MIXINL IN1L Volume' 1"
+    cset "name='MIXINL Output Record Volume' 0"
+
+    cset "name='Main Mic Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='AIF2DAC2L Mixer Left Sidetone Switch' 0"
+    cset "name='AIF2DAC2R Mixer Left Sidetone Switch' 0"
+
+    cset "name='MIXINL IN1L Switch' 0"
+    cset "name='IN1L PGA IN1LN Switch' 0"
+    cset "name='IN1L PGA IN1LP Switch' 0"
+    cset "name='IN1L Switch' 0"
+    cset "name='IN1L ZC Switch' 0"
+
+    cset "name='Main Mic Switch' 0"
+  ]
+
+  Value {
+    CaptureChannels 2
+    CapturePCM "hw:0,0"
+    CapturePriority 100
+    CaptureVolume "IN1L Volume"
+  }
+}
+
+SectionDevice."HeadsetMic" {
+  Comment "external headset mic"
+
+  EnableSequence [
+    cset "name='AIF2DAC2L Mixer Right Sidetone Switch' 1"
+    cset "name='AIF2DAC2R Mixer Right Sidetone Switch' 1"
+
+    cset "name='MIXINR IN1R Switch' 1"
+    cset "name='MIXINR IN1R Volume' 1"
+    cset "name='IN1R PGA IN1RN Switch' 1"
+    cset "name='IN1R PGA IN1RP Switch' 1"
+    cset "name='IN1R Switch' 1"
+    cset "name='IN1R ZC Switch' 1"
+    cset "name='IN1R Volume' 31"
+
+    cset "name='Headset Mic Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='AIF2DAC2L Mixer Right Sidetone Switch' 0"
+    cset "name='AIF2DAC2R Mixer Right Sidetone Switch' 0"
+
+    cset "name='MIXINR IN1R Switch' 0"
+    cset "name='IN1R PGA IN1RN Switch' 0"
+    cset "name='IN1R PGA IN1RP Switch' 0"
+    cset "name='IN1R Switch' 0"
+    cset "name='IN1R ZC Switch' 0"
+
+    cset "name='Headset Mic Switch' 0"
+  ]
+
+  Value {
+    CaptureChannels 2
+    CapturePCM "hw:0,0"
+    CapturePriority 105
+    CaptureVolume "IN1R Volume"
+    JackControl "Headset Mic Jack"
+  }
+}

--- a/usr/share/alsa/ucm/Fascinate4G/Fascinate4G.conf
+++ b/usr/share/alsa/ucm/Fascinate4G/Fascinate4G.conf
@@ -1,0 +1,17 @@
+SectionUseCase."HiFi" {
+  File "hifi"
+  Comment "Hifi audio path"
+}
+
+SectionUseCase."Voice Call" {
+  File "voicecall"
+  Comment "Voice call audio path"
+}
+
+ValueDefaults {
+  PlaybackCTL "hw:0"
+  CaptureCTL "hw:0"
+}
+
+SectionDefaults {
+}

--- a/usr/share/alsa/ucm/Fascinate4G/hifi
+++ b/usr/share/alsa/ucm/Fascinate4G/hifi
@@ -1,0 +1,232 @@
+# Use case Configuration for Mobile device
+# By Inha Song <ideal.song@samsung.com>
+
+SectionVerb {
+  EnableSequence [
+    cset "name='DAC1L Mixer AIF1.1 Switch' 1"
+    cset "name='DAC1R Mixer AIF1.1 Switch' 1"
+    cset "name='DAC1 Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='DAC1L Mixer AIF1.1 Switch' 0"
+    cset "name='DAC1R Mixer AIF1.1 Switch' 0"
+    cset "name='DAC1 Switch' 0"
+  ]
+
+  Value {
+    TQ "Music"
+    CaptureCTL "hw:0"
+    PlaybackCTL "hw:0"
+  }
+}
+
+SectionDevice."Headphones" {
+  Comment "3.5mm Headphones"
+
+  EnableSequence [
+    cset "name='Headphone Switch' 1"
+    cset "name='Headphone Volume' 43"
+    cset "name='Left Headphone Mux' DAC"
+    cset "name='Right Headphone Mux' DAC"
+
+    cset "name='HP Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='Headphone Switch' 0"
+
+    cset "name='HP Switch' 0"
+  ]
+
+  Value {
+    PlaybackChannels 2
+    PlaybackPCM "hw:0,0"
+    PlaybackPriority 110
+    PlaybackVolume "Headphone Volume"
+    JackControl "HP Jack"
+  }
+}
+
+SectionDevice."Speaker" {
+  Comment "built-in Speaker"
+
+  EnableSequence [
+    cset "name='Speaker Switch' 1"
+    cset "name='Speaker Volume' 63"
+    cset "name='Speaker Boost Volume' 6"
+    cset "name='Speaker Mixer Volume' 3"
+    cset "name='SPKL DAC1 Switch' 1"
+
+    cset "name='SPK Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='Speaker Switch' 0"
+    cset "name='SPKL DAC1 Switch' 0"
+
+    cset "name='SPK Switch' 0"
+  ]
+
+  Value {
+    PlaybackChannels 1
+    PlaybackPCM "hw:0,0"
+    PlaybackPriority 105
+    PlaybackVolume "Speaker Volume"
+  }
+}
+
+SectionDevice."Earpiece" {
+  Comment "built-in earpiece, receiver"
+
+  EnableSequence [
+    cset "name='Earpiece Switch' 1"
+    cset "name='Earpiece Mixer Left Output Switch' 1"
+    cset "name='Earpiece Mixer Right Output Switch' 1"
+    cset "name='Left Output Mixer DAC Switch' 1"
+    cset "name='Right Output Mixer DAC Switch' 1"
+
+    cset "name='RCV Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='Earpiece Switch' 0"
+    cset "name='Earpiece Mixer Left Output Switch' 0"
+    cset "name='Earpiece Mixer Right Output Switch' 0"
+    cset "name='Left Output Mixer DAC Switch' 0"
+    cset "name='Right Output Mixer DAC Switch' 0"
+
+    cset "name='RCV Switch' 0"
+  ]
+
+  Value {
+    PlaybackChannels 2
+    PlaybackPCM "hw:0,0"
+    PlaybackPriority 100
+    PlaybackVolume "Earpiece Volume"
+  }
+}
+
+SectionDevice."Line" {
+  Comment "lineout for dock"
+
+
+  EnableSequence [
+# Gain
+    cset "name='LINEOUT2 Volume' 0"
+# FSA9480
+    exec "echo VAUDIO > /sys/devices/platform/i2c-gpio-3/i2c-7/7-0025/switch"
+# Path
+    cset "name='Right Output Mixer DAC Switch' 1"
+    cset "name='Left Output Mixer DAC Switch' 1"
+    cset "name='LINEOUT2N Mixer Left Output Switch' 1"
+    cset "name='LINEOUT2P Mixer Right Output Switch' 1"
+    cset "name='LINEOUT2N Switch' 1"
+    cset "name='LINEOUT2P Switch' 1"
+
+    cset "name='LINE Switch' 1"
+  ]
+
+  DisableSequence [
+# FSA9480
+    exec "echo AUTO > /sys/devices/platform/i2c-gpio-3/i2c-7/7-0025/switch"
+# Path
+    cset "name='Right Output Mixer DAC Switch' 0"
+    cset "name='Left Output Mixer DAC Switch' 0"
+    cset "name='LINEOUT2N Mixer Left Output Switch' 0"
+    cset "name='LINEOUT2P Mixer Right Output Switch' 0"
+    cset "name='LINEOUT2N Switch' 0"
+    cset "name='LINEOUT2P Switch' 0"
+
+    cset "name='LINE Switch' 0"
+  ]
+
+  Value {
+    PlaybackChannels 2
+    PlaybackPCM "hw:0,0"
+    PlaybackPriority 115
+    PlaybackVolume "LINEOUT2 Volume"
+    JackControl "LINE Jack"
+  }
+}
+
+SectionDevice."MainMic" {
+  Comment "built-in main mic"
+
+  EnableSequence [
+    cset "name='AIF1ADCL Source' Left"
+    cset "name='AIF1ADCR Source' Left"
+    cset "name='AIF1ADC1L Mixer ADC/DMIC Switch' 1"
+    cset "name='AIF1ADC1R Mixer ADC/DMIC Switch' 1"
+    cset "name='MIXINL IN1L Switch' 1"
+    cset "name='MIXINL IN1L Volume' 1"
+    cset "name='IN1L PGA IN1LN Switch' 1"
+    cset "name='IN1L PGA IN1LP Switch' 1"
+    cset "name='IN1L Switch' 1"
+    cset "name='IN1L ZC Switch' 1"
+    cset "name='IN1L Volume' 31"
+
+    cset "name='Main Mic Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='AIF1ADCR Source' Right"
+    cset "name='AIF1ADC1L Mixer ADC/DMIC Switch' 0"
+    cset "name='AIF1ADC1R Mixer ADC/DMIC Switch' 0"
+    cset "name='MIXINL IN1L Switch' 0"
+    cset "name='IN1L PGA IN1LN Switch' 0"
+    cset "name='IN1L PGA IN1LP Switch' 0"
+    cset "name='IN1L Switch' 0"
+    cset "name='IN1L ZC Switch' 0"
+
+    cset "name='Main Mic Switch' 0"
+  ]
+
+  Value {
+    CaptureChannels 2
+    CapturePCM "hw:0,0"
+    CapturePriority 100
+    CaptureVolume "IN1L Volume"
+  }
+}
+
+SectionDevice."HeadsetMic" {
+  Comment "external headset mic"
+
+  EnableSequence [
+    cset "name='AIF1ADCL Source' Right"
+    cset "name='AIF1ADCR Source' Right"
+    cset "name='AIF1ADC1L Mixer ADC/DMIC Switch' 1"
+    cset "name='AIF1ADC1R Mixer ADC/DMIC Switch' 1"
+    cset "name='MIXINR IN1R Switch' 1"
+    cset "name='MIXINR IN1R Volume' 1"
+    cset "name='IN1R PGA IN1RN Switch' 1"
+    cset "name='IN1R PGA IN1RP Switch' 1"
+    cset "name='IN1R Switch' 1"
+    cset "name='IN1R ZC Switch' 1"
+    cset "name='IN1R Volume' 31"
+
+    cset "name='Headset Mic Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='AIF1ADCL Source' Left"
+    cset "name='AIF1ADC1L Mixer ADC/DMIC Switch' 0"
+    cset "name='AIF1ADC1R Mixer ADC/DMIC Switch' 0"
+    cset "name='MIXINR IN1R Switch' 0"
+    cset "name='IN1R PGA IN1RN Switch' 0"
+    cset "name='IN1R PGA IN1RP Switch' 0"
+    cset "name='IN1R Switch' 0"
+    cset "name='IN1R ZC Switch' 0"
+
+    cset "name='Headset Mic Switch' 0"
+  ]
+
+  Value {
+    CaptureChannels 2
+    CapturePCM "hw:0,0"
+    CapturePriority 105
+    CaptureVolume "IN1R Volume"
+    JackControl "Headset Mic Jack"
+  }
+}

--- a/usr/share/alsa/ucm/Fascinate4G/voicecall
+++ b/usr/share/alsa/ucm/Fascinate4G/voicecall
@@ -1,0 +1,260 @@
+# Use case Configuration for Mobile device
+# By Inha Song <ideal.song@samsung.com>
+
+SectionVerb {
+  EnableSequence [
+    # Common gain values
+    # 0dB
+    cset "name='DAC1 Volume' 96"
+
+    # 0dB
+    cset "name='DAC2 Volume' 96"
+
+    cset "name='DAC2 Right Sidetone Volume' 12"
+    cset "name='DAC2 Left Sidetone Volume' 12"
+    cset "name='DAC OSR' 1"
+    cset "name='ADC OSR' 0"
+
+    cset "name='DAC1R Mixer AIF2 Switch' 1"
+    cset "name='DAC1L Mixer AIF2 Switch' 1"
+    cset "name='DAC1 Switch' 1"
+
+    # DAC2 is connected to AIF2
+    cset "name='DAC2 Switch' 1"
+
+    cset "name='Modem In Switch' 1"
+    cset "name='Modem Out Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='DAC1R Mixer AIF2 Switch' 0"
+    cset "name='DAC1L Mixer AIF2 Switch' 0"
+    cset "name='DAC1 Switch' 0"
+
+    cset "name='DAC2 Switch' 0"
+
+    cset "name='Modem In Switch' 0"
+    cset "name='Modem Out Switch' 0"
+  ]
+
+  Value {
+    TQ "Voice"
+    CaptureCTL "hw:0"
+    PlaybackCTL "hw:0"
+  }
+}
+
+SectionDevice."Headphones" {
+  Comment "3.5mm Headphones"
+
+  EnableSequence [
+    cset "name='Headphone Switch' 1"
+    cset "name='Headphone Volume' 43"
+    cset "name='Left Headphone Mux' DAC"
+    cset "name='Right Headphone Mux' DAC"
+
+    cset "name='HP Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='Headphone Switch' 0"
+
+    cset "name='HP Switch' 0"
+  ]
+
+  Value {
+    PlaybackChannels 2
+    PlaybackPCM "hw:0,0"
+    PlaybackPriority 110
+    PlaybackVolume "Headphone Volume"
+    JackControl "HP Jack"
+  }
+}
+
+SectionDevice."Speaker" {
+  Comment "built-in Speaker"
+
+  EnableSequence [
+    cset "name='Speaker Switch' 1"
+    cset "name='Speaker Volume' 63"
+    cset "name='Speaker Boost Volume' 6"
+    cset "name='Speaker Mixer Volume' 3"
+    cset "name='SPKL DAC1 Switch' 1"
+
+    cset "name='SPK Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='Speaker Switch' 0"
+    cset "name='SPKL DAC1 Switch' 0"
+
+    cset "name='SPK Switch' 0"
+  ]
+
+  Value {
+    PlaybackChannels 1
+    PlaybackPCM "hw:0,0"
+    PlaybackPriority 100
+    PlaybackVolume "Speaker Volume"
+  }
+}
+
+SectionDevice."Earpiece" {
+  Comment "built-in earpiece, receiver"
+
+  EnableSequence [
+    cset "name='Left Output Mixer DAC Volume' 7"
+    cset "name='Right Output Mixer DAC Volume' 7"
+    cset "name='Output Volume' 63"
+    cset "name='Earpiece Volume' 1"
+
+    cset "name='Earpiece Switch' 1"
+    cset "name='Earpiece Mixer Left Output Switch' 1"
+    cset "name='Earpiece Mixer Right Output Switch' 1"
+    cset "name='Left Output Mixer DAC Switch' 1"
+    cset "name='Right Output Mixer DAC Switch' 1"
+
+    cset "name='RCV Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='Earpiece Switch' 0"
+    cset "name='Earpiece Mixer Left Output Switch' 0"
+    cset "name='Earpiece Mixer Right Output Switch' 0"
+    cset "name='Left Output Mixer DAC Switch' 0"
+    cset "name='Right Output Mixer DAC Switch' 0"
+
+    cset "name='RCV Switch' 0"
+  ]
+
+  Value {
+    PlaybackChannels 2
+    PlaybackPCM "hw:0,0"
+    PlaybackPriority 105
+    PlaybackVolume "Earpiece Volume"
+  }
+}
+
+SectionDevice."Line" {
+  Comment "lineout for dock"
+
+
+  EnableSequence [
+# Gain
+    cset "name='LINEOUT2 Volume' 0"
+# FSA9480
+    exec "echo VAUDIO > /sys/devices/platform/i2c-gpio-3/i2c-7/7-0025/switch"
+# Path
+    cset "name='Right Output Mixer DAC Switch' 1"
+    cset "name='Left Output Mixer DAC Switch' 1"
+    cset "name='LINEOUT2N Mixer Left Output Switch' 1"
+    cset "name='LINEOUT2P Mixer Right Output Switch' 1"
+    cset "name='LINEOUT2N Switch' 1"
+    cset "name='LINEOUT2P Switch' 1"
+
+    cset "name='LINE Switch' 1"
+  ]
+
+  DisableSequence [
+# FSA9480
+    exec "echo AUTO > /sys/devices/platform/i2c-gpio-3/i2c-7/7-0025/switch"
+# Path
+    cset "name='Right Output Mixer DAC Switch' 0"
+    cset "name='Left Output Mixer DAC Switch' 0"
+    cset "name='LINEOUT2N Mixer Left Output Switch' 0"
+    cset "name='LINEOUT2P Mixer Right Output Switch' 0"
+    cset "name='LINEOUT2N Switch' 0"
+    cset "name='LINEOUT2P Switch' 0"
+
+    cset "name='LINE Switch' 0"
+  ]
+
+  Value {
+    PlaybackChannels 2
+    PlaybackPCM "hw:0,0"
+    PlaybackPriority 115
+    PlaybackVolume "LINEOUT2 Volume"
+    JackControl "LINE Jack"
+  }
+}
+
+SectionDevice."MainMic" {
+  Comment "built-in main mic"
+
+  EnableSequence [
+    cset "name='AIF2DAC2L Mixer Left Sidetone Switch' 1"
+    cset "name='AIF2DAC2R Mixer Left Sidetone Switch' 1"
+
+    cset "name='MIXINL IN1L Switch' 1"
+    cset "name='MIXINL IN1L Volume' 1"
+    cset "name='IN1L PGA IN1LN Switch' 1"
+    cset "name='IN1L PGA IN1LP Switch' 1"
+    cset "name='IN1L Switch' 1"
+    cset "name='IN1L ZC Switch' 1"
+    cset "name='IN1L Volume' 25"
+    cset "name='MIXINL IN1L Volume' 1"
+    cset "name='MIXINL Output Record Volume' 0"
+
+    cset "name='Main Mic Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='AIF2DAC2L Mixer Left Sidetone Switch' 0"
+    cset "name='AIF2DAC2R Mixer Left Sidetone Switch' 0"
+
+    cset "name='MIXINL IN1L Switch' 0"
+    cset "name='IN1L PGA IN1LN Switch' 0"
+    cset "name='IN1L PGA IN1LP Switch' 0"
+    cset "name='IN1L Switch' 0"
+    cset "name='IN1L ZC Switch' 0"
+
+    cset "name='Main Mic Switch' 0"
+  ]
+
+  Value {
+    CaptureChannels 2
+    CapturePCM "hw:0,0"
+    CapturePriority 100
+    CaptureVolume "IN1L Volume"
+  }
+}
+
+SectionDevice."HeadsetMic" {
+  Comment "external headset mic"
+
+  EnableSequence [
+    cset "name='AIF2DAC2L Mixer Right Sidetone Switch' 1"
+    cset "name='AIF2DAC2R Mixer Right Sidetone Switch' 1"
+
+    cset "name='MIXINR IN1R Switch' 1"
+    cset "name='MIXINR IN1R Volume' 1"
+    cset "name='IN1R PGA IN1RN Switch' 1"
+    cset "name='IN1R PGA IN1RP Switch' 1"
+    cset "name='IN1R Switch' 1"
+    cset "name='IN1R ZC Switch' 1"
+    cset "name='IN1R Volume' 31"
+
+    cset "name='Headset Mic Switch' 1"
+  ]
+
+  DisableSequence [
+    cset "name='AIF2DAC2L Mixer Right Sidetone Switch' 0"
+    cset "name='AIF2DAC2R Mixer Right Sidetone Switch' 0"
+
+    cset "name='MIXINR IN1R Switch' 0"
+    cset "name='IN1R PGA IN1RN Switch' 0"
+    cset "name='IN1R PGA IN1RP Switch' 0"
+    cset "name='IN1R Switch' 0"
+    cset "name='IN1R ZC Switch' 0"
+
+    cset "name='Headset Mic Switch' 0"
+  ]
+
+  Value {
+    CaptureChannels 2
+    CapturePCM "hw:0,0"
+    CapturePriority 105
+    CaptureVolume "IN1R Volume"
+    JackControl "Headset Mic Jack"
+  }
+}


### PR DESCRIPTION
HiFi and Voice Call are confirmed to work on Fascinate4G.
FM Radio is untested and is copied from the Tizen WM1811 UCM conf files

@PabloPL When you have a chance, could you please try the FM radio paths?  If they don't work, I'll try parsing the datasheet to figure out what's connected.  The WM8994 datasheet is available at https://statics.cirrus.com/pubs/proDatasheet/WM8994_Rev4.6.pdf

In terms of kernel-side, try https://github.com/xc-racer99/linux/tree/modem-audio (currently at https://github.com/xc-racer99/linux/commit/1a00bb86f30cfcf2fb57280ab40025cc1c6dd07e)